### PR TITLE
make api for url info

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.jsoup:jsoup:1.15.2'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/backend/src/main/java/io/gurumi/core/blocks/service/OpenGraphService.java
+++ b/backend/src/main/java/io/gurumi/core/blocks/service/OpenGraphService.java
@@ -1,0 +1,51 @@
+package io.gurumi.core.blocks.service;
+
+import io.gurumi.core.blocks.ui.dto.UrlInfoResponse;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Service
+public class OpenGraphService {
+
+
+    private String getDomainName(String url) throws URISyntaxException {
+        URI uri = new URI(url);
+        String domain = uri.getHost();
+        return domain.startsWith("www.") ? domain.substring(4) : domain;
+    }
+
+    public UrlInfoResponse getHtml(String targetUrl){
+
+
+
+        try{
+            if(!targetUrl.startsWith("http") && !targetUrl.startsWith("https")){
+                targetUrl = "http://" + targetUrl;
+            }
+            Document document = Jsoup.connect(targetUrl).get();
+            Element meta_title = document.select("meta[property=og:title]").first();
+            Element meta_description = document.select("meta[property=og:description]").first();
+            Element meta_image_url = document.select("meta[property=og:image]").first();
+
+
+            String title = meta_title.attr("content");
+            String imageUrl = meta_image_url.attr("content");
+            String description = meta_description.attr("content");
+            String domainName = getDomainName(targetUrl);
+
+            return new UrlInfoResponse(title,description,imageUrl,domainName);
+
+
+
+
+        }catch (Exception e){
+            System.out.println(e.getMessage());
+        }
+        return new UrlInfoResponse(null,null,null,null);
+    }
+}

--- a/backend/src/main/java/io/gurumi/core/blocks/ui/UrlInfoController.java
+++ b/backend/src/main/java/io/gurumi/core/blocks/ui/UrlInfoController.java
@@ -1,0 +1,26 @@
+package io.gurumi.core.blocks.ui;
+
+import io.gurumi.core.blocks.service.OpenGraphService;
+import io.gurumi.core.blocks.ui.dto.UrlInfoResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/link")
+public class UrlInfoController {
+
+    private final OpenGraphService openGraphService;
+
+    public UrlInfoController(OpenGraphService openGraphService) {
+        this.openGraphService = openGraphService;
+    }
+
+    @GetMapping()
+    public ResponseEntity<UrlInfoResponse> getOpenGraph(@RequestParam String url){
+        UrlInfoResponse body = openGraphService.getHtml(url);
+        return ResponseEntity.ok(body);
+    }
+}

--- a/backend/src/main/java/io/gurumi/core/blocks/ui/dto/UrlInfoResponse.java
+++ b/backend/src/main/java/io/gurumi/core/blocks/ui/dto/UrlInfoResponse.java
@@ -1,0 +1,34 @@
+package io.gurumi.core.blocks.ui.dto;
+
+public class UrlInfoResponse {
+
+    private final String title;
+    private final String description;
+    private final String imgUrl;
+    private final String domainName;
+
+
+
+    public UrlInfoResponse(String title, String description, String imgUrl, String domainName) {
+        this.title = title;
+        this.description = description;
+        this.imgUrl = imgUrl;
+        this.domainName = domainName;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getImgUrl() {
+        return imgUrl;
+    }
+
+    public String getDomainName() {
+        return domainName;
+    }
+}


### PR DESCRIPTION
# 설명
클라이언트에서 url을 보내면 해당 url의 썸네일 생성을 위한 정보를 전달하는 API를 만들었습니다. Jsoup을 이용하여 해당 url의 html을 가져오고 해당 html의 og tag를 파싱하여 title, description, image url, domain name 을 전달합니다.

# 생각
프론트에서 이 정보를 이용하여 썸네일을 만들었으면 좋겠습니다.

close #19 